### PR TITLE
chore: make chore commits visible in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,7 +14,7 @@
         { "type": "perf", "section": "⚡ Performance", "hidden": false },
         { "type": "refactor", "section": "♻️ Refactoring", "hidden": false },
         { "type": "docs", "section": "📚 Documentation", "hidden": false },
-        { "type": "chore", "section": "🔧 Chores", "hidden": true },
+        { "type": "chore", "section": "🔧 Chores", "hidden": false },
         { "type": "test", "section": "✅ Tests", "hidden": true },
         { "type": "ci", "section": "👷 CI/CD", "hidden": true }
       ],


### PR DESCRIPTION
## Changes

This PR makes chore commits visible in Release Please, allowing dependency upgrades and maintenance tasks to trigger releases.

### Updates
- Changed `chore` section `hidden` from `true` to `false` in release-please-config.json
- Dependency upgrades and maintenance tasks will now appear in changelog
- These changes will trigger release PRs when merged