### PR TITLE
fix(server): send gRPC CANCELLED trailers on handler cancel when response started

### DIFF
--- a/.runtime_ci/autodoc.json
+++ b/.runtime_ci/autodoc.json
@@ -54,8 +54,8 @@
         "api_reference",
         "examples"
       ],
-      "hash": "2881ac49f62a26bb3529c1a69310a258f2b00e6fef2e83f0844e364ff71a0308",
-      "last_updated": "2026-03-25T02:14:38.177937Z"
+      "hash": "4e56393838d2965a10b0116366916ef497025534211ed3e13616009d195345fe",
+      "last_updated": "2026-03-28T18:26:16.636324Z"
     },
     {
       "id": "shared",
@@ -99,8 +99,8 @@
       "generate": [
         "quickstart"
       ],
-      "hash": "e3b536795e1c3a5b55cafb4b66365dfdd92cdae88457a36f7c2d1b9bb76c317b",
-      "last_updated": "2026-03-25T02:14:38.177948Z"
+      "hash": "e0227c92333bded03a94b2287b9ce1a0dcb72dffa479e5c14f291a789a48f033",
+      "last_updated": "2026-03-28T18:26:16.637092Z"
     },
     {
       "id": "generated",

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,320 +1,256 @@
-# gRPC Dart Quickstart
+# QUICKSTART
 
 ## 1. Overview
-The `grpc` module provides a pure-Dart implementation of the gRPC framework for building robust, cross-platform APIs. It features support for both clients and servers, HTTP/2 multiplexing, local IPC (Unix Domain Sockets / Windows Named Pipes), interceptors, and gRPC-Web.
+The `grpc` package provides a pure Dart implementation of gRPC for both clients and servers. It enables you to communicate between services using HTTP/2, support browser-based clients via gRPC-Web, and use secure local IPC mechanisms like Unix domain sockets and Windows named pipes. The library includes all the foundational building blocks required to run and consume gRPC services, including authentication, interceptors, error handling, and keep-alive configuration.
 
 ## 2. Import
-Depending on your target platform and features, use one of the following imports:
+Depending on your platform and requirements, you can import the appropriate entry points for the package. Always use the `package:grpc-dart/` prefix for imports in this module.
 
 ```dart
-// Core gRPC library for clients, servers, and IPC
+// Standard gRPC for native platforms (server and client)
 import 'package:grpc-dart/grpc.dart';
 
-// For browser applications using gRPC-Web
+// gRPC-Web exclusively for browser platforms
 import 'package:grpc-dart/grpc_web.dart';
 
-// Automatic selection between gRPC (native) and gRPC-Web (browser)
+// Cross-platform client channel (automatically chooses HTTP/2 or gRPC-Web)
 import 'package:grpc-dart/grpc_or_grpcweb.dart';
 
-// Optional: For pre-generated protobuf error details and durations
+// Minimal API for generated service stubs (typically used by protoc-gen-dart)
+import 'package:grpc-dart/service_api.dart';
+
+// Provided Google RPC error details and protobuf Duration classes
 import 'package:grpc-dart/protos.dart';
 ```
 
 ## 3. Setup
-gRPC heavily relies on generated code. While the `protoc` compiler typically generates your `Service` and `Client` stubs, the following examples illustrate how to construct and configure the underlying `Server` and `ClientChannel`.
+
+### Client Setup
+To connect to a gRPC server, you configure a channel. Use `ClientChannel` for native apps, `GrpcWebClientChannel` for web, or `GrpcOrGrpcWebClientChannel` for cross-platform code:
 
 ```dart
 import 'package:grpc-dart/grpc.dart';
 
-// 1. Setting up a client channel
 final channel = ClientChannel(
-  'localhost',
-  port: 50051,
+  'api.example.com',
+  port: 443,
   options: const ChannelOptions(
-    credentials: ChannelCredentials.insecure(),
-  ),
-);
-
-// 2. Setting up a server
-final server = Server.create(
-  services: [], // Add your generated services here
-  codecRegistry: CodecRegistry(
-    codecs: const [GzipCodec(), IdentityCodec()],
+    credentials: ChannelCredentials.secure(),
+    idleTimeout: Duration(minutes: 5),
   ),
 );
 ```
 
-## 4. Constructing Messages
-Protobuf messages in Dart are best constructed using the cascade operator (`..`) for a clean, builder-like syntax.
+### Server Setup
+To create a standard HTTP/2 gRPC server, use the `Server.create` factory and pass in your generated service implementations:
 
 ```dart
-import 'package:fixnum/fixnum.dart';
-import 'package:grpc-dart/protos.dart';
-
-// Constructing a RetryInfo message
-final retryInfo = RetryInfo()
-  ..retryDelay = (Duration()
-    ..seconds = Int64(5)
-    ..nanos = 0);
-
-// Constructing a BadRequest message with multiple field violations
-final badRequest = BadRequest()
-  ..fieldViolations.addAll([
-    BadRequest_FieldViolation()
-      ..field_1 = 'email'
-      ..description = 'Invalid email format',
-    BadRequest_FieldViolation()
-      ..field_1 = 'password'
-      ..description = 'Password too short',
-  ]);
-```
-
-## 5. Common Operations
-
-> **Note:** `MyService` and `MyClient` in these examples represent the stubs that are typically generated for you by `protoc`.
-
-### Starting a Server
-```dart
-import 'dart:async';
 import 'package:grpc-dart/grpc.dart';
 
-class MyService extends Service {
-  @override
-  String get $name => 'MyService';
+// Assumes MyServiceImpl extends the generated Service class
+final server = Server.create(
+  services: [ /* MyServiceImpl() */ ],
+  codecRegistry: CodecRegistry(codecs: const [GzipCodec(), IdentityCodec()]),
+);
+```
 
-  MyService() {
-    $addMethod(ServiceMethod<int, int>(
-      'MyMethod',
-      _myMethod,
-      false,
-      false,
-      (List<int> request) => request.isNotEmpty ? request[0] : 0,
-      (int response) => [response],
-    ));
-  }
+## 4. Common Operations
 
-  Future<int> _myMethod(ServiceCall call, int request) async {
-    return request * 2;
-  }
-}
+### Starting a gRPC Server
+```dart
+import 'package:grpc-dart/grpc.dart';
 
 Future<void> main() async {
-  final server = Server.create(services: [MyService()]);
+  final server = Server.create(services: [ /* MyServiceImpl() */ ]);
   await server.serve(port: 50051);
   print('Server listening on port ${server.port}...');
 }
 ```
 
-### Making a Client Call
-```dart
-import 'dart:async';
-import 'package:grpc-dart/grpc.dart';
-
-class MyClient extends Client {
-  MyClient(ClientChannel channel) : super(channel);
-
-  ResponseFuture<int> myMethod(int request, {CallOptions? options}) {
-    final method = ClientMethod<int, int>(
-      '/MyService/MyMethod',
-      (int value) => [value],
-      (List<int> value) => value.isNotEmpty ? value[0] : 0,
-    );
-    return $createUnaryCall(method, request, options: options);
-  }
-}
-
-Future<void> main() async {
-  final channel = ClientChannel(
-    'localhost',
-    port: 50051,
-    options: const ChannelOptions(credentials: ChannelCredentials.insecure()),
-  );
-  
-  final client = MyClient(channel);
-  
-  try {
-    final response = await client.myMethod(
-      42, 
-      options: CallOptions(timeout: const Duration(seconds: 5)),
-    );
-    print('Response: $response');
-  } on GrpcError catch (e) {
-    print('gRPC Error: ${e.codeName} - ${e.message}');
-  } finally {
-    await channel.shutdown();
-  }
-}
-```
-
-### Connecting via gRPC-Web
-For web applications, use `GrpcWebClientChannel` or `GrpcOrGrpcWebClientChannel`.
+### Creating a Cross-Platform Client Channel
+This channel automatically uses `ClientChannel` on native platforms and `GrpcWebClientChannel` on the web, making it ideal for Flutter projects.
 
 ```dart
-import 'package:grpc-dart/grpc_web.dart';
+import 'package:grpc-dart/grpc_or_grpcweb.dart';
 
-Future<void> main() async {
-  final channel = GrpcWebClientChannel.xhr(
-    Uri.parse('https://localhost:8080'),
-  );
+final channel = GrpcOrGrpcWebClientChannel.toSingleEndpoint(
+  host: 'api.example.com',
+  port: 443,
+  transportSecure: true,
+);
 
-  // In a real application: 
-  // final client = MyClient(channel);
-  // await client.myMethod(42, options: WebCallOptions(bypassCorsPreflight: true));
-}
+// final stub = MyServiceClient(channel);
 ```
 
-### Using Local IPC
-You can easily create secure, local-only communication across Unix Domain Sockets (macOS/Linux) and Named Pipes (Windows).
+### Making a Call with Interceptors and Options
+You can configure timeouts and metadata per-call using `CallOptions` and intercept operations using `ClientInterceptor`.
 
 ```dart
 import 'package:grpc-dart/grpc.dart';
 
-Future<void> main() async {
-  // Start a local IPC server
-  final server = LocalGrpcServer('my-ipc-service', services: []);
-  await server.serve();
-  
-  // Connect via a local IPC channel
-  final channel = LocalGrpcChannel('my-ipc-service');
-  // final client = MyClient(channel);
-}
+final options = CallOptions(
+  timeout: Duration(seconds: 30),
+  metadata: {'x-custom-header': 'value'},
+);
+
+// Example stub call:
+// final response = await stub.myMethod(request, options: options);
 ```
 
-
-## 6. Configuration
-The package can be finely tuned using various option objects:
-
-- **`ChannelOptions`**: Configures the `ClientChannel` with properties like `credentials` (e.g., `ChannelCredentials.secure()`), `idleTimeout`, and `backoffStrategy`.
-- **`CallOptions`**: Used per RPC to set custom `metadata`, specify a `timeout`, or apply a specific `compression` codec.
-- **`WebCallOptions`**: Extended options for gRPC-Web calls to handle CORS via parameters like `bypassCorsPreflight` and `withCredentials`.
-- **`ServerKeepAliveOptions`**: Defines ping intervals and bad-ping limits to protect the server from DDoS and keep connections alive.
-- **`CodecRegistry`**: Allows payload compression configuring codecs like `GzipCodec` and `IdentityCodec`.
-
-## 7. Included Protobuf Messages
-The package provides pre-generated standard Google protobuf messages (from `google/protobuf` and `google/rpc`) that are commonly used within gRPC error details. Use `import 'package:grpc-dart/protos.dart';` to access these models.
-
-### `Any` (from `google/protobuf/any.proto`)
-Contains an arbitrary serialized protocol buffer message along with a URL that describes the type.
-- `typeUrl` (`String`): A URL/resource name that uniquely identifies the type.
-- `value` (`List<int>`): Must be a valid serialized protocol buffer of the above specified type.
-
-### `Duration` (from `google/protobuf/duration.proto`)
-Represents a signed, fixed-length span of time.
-- `seconds` (`Int64`): Signed seconds of the span of time. Must be from -315,576,000,000 to +315,576,000,000 inclusive.
-- `nanos` (`int`): Signed fractions of a second at nanosecond resolution of the span of time. Must be from -999,999,999 to +999,999,999 inclusive.
-
-### `Status` (from `google/rpc/status.proto`)
-Defines a logical error model suitable for REST and RPC APIs.
-- `code` (`int`): The status code, which should be an enum value of `google.rpc.Code` (see `StatusCode` in `grpc-dart`).
-- `message` (`String`): A developer-facing error message, which should be in English.
-- `details` (`List<Any>`): A list of messages that carry the error details.
-
-### `RetryInfo` (from `google/rpc/error_details.proto`)
-Describes when the clients can retry a failed request.
-- `retryDelay` (`Duration`): Clients should wait at least this long between retrying the same request.
-
-### `DebugInfo` (from `google/rpc/error_details.proto`)
-Describes additional debugging info.
-- `stackEntries` (`List<String>`): The stack trace entries indicating where the error occurred.
-- `detail` (`String`): Additional debugging information provided by the server.
-
-### `QuotaFailure` (from `google/rpc/error_details.proto`)
-Describes how a quota check failed.
-- `violations` (`List<QuotaFailure_Violation>`): Describes all quota violations.
-
-### `QuotaFailure_Violation` (from `google/rpc/error_details.proto`)
-- `subject` (`String`): The subject on which the quota check failed.
-- `description` (`String`): A description of how the quota check failed.
-
-### `ErrorInfo` (from `google/rpc/error_details.proto`)
-Describes the cause of the error with structured details.
-- `reason` (`String`): The reason of the error.
-- `domain` (`String`): The logical grouping to which the "reason" belongs.
-- `metadata` (`Map<String, String>`): Additional structured details about this error.
-
-### `PreconditionFailure` (from `google/rpc/error_details.proto`)
-Describes what preconditions have failed.
-- `violations` (`List<PreconditionFailure_Violation>`): Describes all precondition violations.
-
-### `PreconditionFailure_Violation` (from `google/rpc/error_details.proto`)
-- `type` (`String`): The type of PreconditionFailure.
-- `subject` (`String`): The subject, relative to the type, that failed.
-- `description` (`String`): A description of how the precondition failed.
-
-### `BadRequest` (from `google/rpc/error_details.proto`)
-Describes violations in a client request.
-- `fieldViolations` (`List<BadRequest_FieldViolation>`): Describes all violations in a client request.
-
-### `BadRequest_FieldViolation` (from `google/rpc/error_details.proto`)
-- `field_1` (`String`): A path leading to a field in the request body. *(Note: Generated as `field_1` in Dart to avoid conflicts).*
-- `description` (`String`): A description of why the request element is bad.
-
-### `RequestInfo` (from `google/rpc/error_details.proto`)
-Contains metadata about the request that clients can attach when filing a bug.
-- `requestId` (`String`): An opaque string that should only be interpreted by the service generating it.
-- `servingData` (`String`): Any data that was used to serve this request.
-
-### `ResourceInfo` (from `google/rpc/error_details.proto`)
-Describes the resource that is being accessed.
-- `resourceType` (`String`): A name for the type of resource being accessed.
-- `resourceName` (`String`): The name of the resource being accessed.
-- `owner` (`String`): The owner of the resource (optional).
-- `description` (`String`): Describes what error is encountered when accessing this resource.
-
-### `Help` (from `google/rpc/error_details.proto`)
-Provides links to documentation or for performing an out of band action.
-- `links` (`List<Help_Link>`): URL(s) pointing to additional information.
-
-### `Help_Link` (from `google/rpc/error_details.proto`)
-- `description` (`String`): Describes what the link offers.
-- `url` (`String`): The URL of the link.
-
-### `LocalizedMessage` (from `google/rpc/error_details.proto`)
-Provides a localized error message that is safe to return to the user.
-- `locale` (`String`): The locale used following the specification defined at http://www.rfc-editor.org/rfc/bcp/bcp47.txt.
-- `message` (`String`): The localized error message in the above locale.
-
-## 8. Advanced Error Handling
-gRPC Dart allows you to attach structured error details to your RPC responses using the `google.rpc.Status` model.
+### Error Handling with Rich Details
+gRPC supports rich error details using the `google.rpc.Status` model. You can pack specific error information like `RetryInfo`, `ErrorInfo`, or `BadRequest` into your errors.
 
 ```dart
+import 'package:fixnum/fixnum.dart';
 import 'package:grpc-dart/grpc.dart';
 import 'package:grpc-dart/protos.dart';
 
-// Server-side: Throwing a detailed error
-Future<void> handleRequest() async {
-  final status = Status()
-    ..code = StatusCode.invalidArgument
-    ..message = 'Invalid request parameters'
-    ..details.add(Any.pack(BadRequest()
-      ..fieldViolations.add(BadRequest_FieldViolation()
-        ..field_1 = 'user_id'
-        ..description = 'Must be a valid UUID')));
+void handleGrpcError(GrpcError error) {
+  print('Error code: ${error.code}');
+  print('Error message: ${error.message}');
 
-  throw GrpcError.custom(
-    status.code,
-    status.message,
-    status.details,
-  );
-}
-
-// Client-side: Handling a detailed error
-try {
-  await stub.someMethod(request);
-} on GrpcError catch (e) {
-  print('Error: ${e.message}');
-  if (e.details != null) {
-    for (final detail in e.details!) {
-      if (detail is BadRequest) {
+  if (error.details != null) {
+    for (final detail in error.details!) {
+      if (detail is RetryInfo) {
+        // Clients should wait at least this long between retrying the same request.
+        print('Retry delay: ${detail.retryDelay.seconds}s');
+      } else if (detail is ErrorInfo) {
+        // The reason of the error.
+        print('Reason: ${detail.reason}');
+        // The logical grouping to which the "reason" belongs.
+        print('Domain: ${detail.domain}');
+        // Additional structured details.
+        detail.metadata.forEach((key, value) => print('$key: $value'));
+      } else if (detail is BadRequest) {
         for (final violation in detail.fieldViolations) {
-          print('Violation on ${violation.field_1}: ${violation.description}');
+          // A path leading to a field in the request body.
+          print('Field: ${violation.field_1}');
+          // A description of why the request element is bad.
+          print('Description: ${violation.description}');
         }
       }
     }
   }
 }
+
+// Example of creating a rich error on the server:
+GrpcError createRichError() {
+  final errorInfo = ErrorInfo()
+    ..reason = 'API_DISABLED'
+    ..domain = 'googleapis.com'
+    ..metadata['resource'] = 'projects/123';
+
+  final retryInfo = RetryInfo()
+    ..retryDelay = (Duration()..seconds = Int64(30));
+
+  return GrpcError.custom(
+    StatusCode.unavailable,
+    'Service is currently disabled.',
+    [errorInfo, retryInfo],
+  );
+}
 ```
 
-## 9. Related Modules
-- **`googleapis_auth`**: Helpful for generating OAuth 2.0 access credentials using `ServiceAccountAuthenticator` or `ComputeEngineAuthenticator` which can be injected into client calls via the `CallOptions` providers.
-- **`protobuf`**: Essential for generating and representing strongly-typed messages using Google's protocol buffers compiler (`protoc`).
+### Setting up a Local IPC Server and Client
+For local-only communication, use `LocalGrpcServer` and `LocalGrpcChannel` which automatically utilize Unix domain sockets (macOS/Linux) or Named Pipes (Windows).
+
+```dart
+import 'package:grpc-dart/grpc.dart';
+
+// Server side
+final localServer = LocalGrpcServer('my-service', services: [ /* MyServiceImpl() */ ]);
+await localServer.serve();
+
+// Client side
+final localChannel = LocalGrpcChannel('my-service');
+// final stub = MyServiceClient(localChannel);
+```
+
+## 5. Configuration
+
+Various options can be provided when creating channels or servers to control their behavior:
+
+*   **`ChannelOptions`**: Configures client timeouts (`connectTimeout`, `idleTimeout`), keep-alive (`keepAlive` using `ClientKeepAliveOptions`), backoff strategy (`backoffStrategy`), max inbound message size (`maxInboundMessageSize`), and security (`credentials` using `ChannelCredentials`).
+*   **`ServerKeepAliveOptions`**: Configures server-side keep-alive behavior like `minIntervalBetweenPingsWithoutData` and `maxBadPings` to protect against DDoS.
+*   **`CodecRegistry`**: Allows configuration of message compression mechanisms (e.g., `GzipCodec`, `IdentityCodec`).
+*   **Authentication**: Configured via `ChannelCredentials` for TLS, or classes like `JwtServiceAccountAuthenticator`, `ComputeEngineAuthenticator`, and `ServiceAccountAuthenticator` from `package:grpc-dart/grpc.dart` for Google Cloud authentication workflows.
+
+## 6. Message Types and Models
+The package provides several built-in message types for common gRPC patterns, primarily available via `package:grpc-dart/protos.dart`. Dart protobuf generated code uses `camelCase` for field access.
+
+### google.rpc.Status
+A logical error model suitable for different programming environments.
+- `code`: The status code (enum value of `google.rpc.Code`).
+- `message`: A developer-facing error message (English).
+- `details`: A list of messages that carry the error details (as `google.protobuf.Any`).
+
+### google.rpc.RetryInfo
+Describes when the clients can retry a failed request.
+- `retryDelay`: Clients should wait at least this long before retrying.
+
+### google.rpc.DebugInfo
+Describes additional debugging info.
+- `stackEntries`: The stack trace entries indicating where the error occurred.
+- `detail`: Additional debugging information provided by the server.
+
+### google.rpc.QuotaFailure
+Describes how a quota check failed.
+- `violations`: List of `Violation` messages.
+  - `Violation.subject`: The subject on which the quota check failed.
+  - `Violation.description`: A description of how the quota check failed.
+
+### google.rpc.ErrorInfo
+Describes the cause of the error with structured details.
+- `reason`: A constant value identifying the proximate cause.
+- `domain`: The logical grouping to which the "reason" belongs.
+- `metadata`: Additional structured details about this error.
+
+### google.rpc.PreconditionFailure
+Describes what preconditions have failed.
+- `violations`: List of `Violation` messages.
+  - `Violation.type`: The type of PreconditionFailure (e.g., "TOS").
+  - `Violation.subject`: The subject relative to the type that failed.
+  - `Violation.description`: A description of how the precondition failed.
+
+### google.rpc.BadRequest
+Describes violations in a client request (syntactic aspects).
+- `fieldViolations`: List of `FieldViolation` messages.
+  - `FieldViolation.field_1`: A path leading to a field in the request body. (*Note: suffixed with _1 to avoid conflict with Dart keyword*).
+  - `FieldViolation.description`: A description of why the request element is bad.
+
+### google.rpc.RequestInfo
+Contains metadata about the request for filing bugs or feedback.
+- `requestId`: An opaque string identifying the request in service logs.
+- `servingData`: Any data used to serve this request.
+
+### google.rpc.ResourceInfo
+Describes the resource being accessed.
+- `resourceType`: A name for the type of resource.
+- `resourceName`: The name of the resource being accessed.
+- `owner`: The owner of the resource (optional).
+- `description`: Describes what error is encountered when accessing this resource.
+
+### google.rpc.Help
+Provides links to documentation or out-of-band actions.
+- `links`: List of `Link` messages.
+  - `Link.description`: Describes what the link offers.
+  - `Link.url`: The URL of the link.
+
+### google.rpc.LocalizedMessage
+Provides a localized error message safe to return to the user.
+- `locale`: The locale used (e.g., "en-US").
+- `message`: The localized error message.
+
+### google.protobuf.Duration
+A signed, fixed-length span of time.
+- `seconds`: Signed seconds of the span.
+- `nanos`: Signed fractions of a second at nanosecond resolution.
+
+### google.protobuf.Any
+Contains an arbitrary serialized protocol buffer message along with a URL.
+- `typeUrl`: A URL/resource name uniquely identifying the type of the serialized message.
+- `value`: Must be a valid serialized protocol buffer of the specified type.
+
+## 7. Related Modules
+
+*   **Protobuf Generator**: To generate the Dart stubs for your `Service` and `Client` classes, you will use the `protoc_plugin` package. The generated code relies heavily on the `package:grpc-dart/service_api.dart` and `package:grpc-dart/protos.dart` imports.

--- a/docs/server/API_REFERENCE.md
+++ b/docs/server/API_REFERENCE.md
@@ -1,13 +1,13 @@
 # gRPC Server API Reference
 
-The **gRPC Server** module provides the core implementation for hosting gRPC services in Dart. It supports standard TCP/IP servers (with optional TLS), local IPC (Unix Domain Sockets and Windows Named Pipes), interceptors, and keepalive management.
+This document provides a comprehensive API reference for the **gRPC Server** module. It covers the core classes, server implementations, and configuration options required for building gRPC servers in Dart.
 
-## 1. Naming Conventions in Generated Code
+## 0. Naming Conventions (Protobuf to Dart)
 
-Protobuf definitions frequently use `snake_case` for field names. When the Dart code is generated, these are automatically converted to `camelCase` to follow Dart's idiomatic style.
+When implementing a gRPC service in Dart, all `snake_case` field names from the `.proto` files are automatically converted to `camelCase` in the generated Dart messages.
 
-| Proto Field (snake_case) | Dart Field (camelCase) |
-| :--- | :--- |
+| Proto Field Name | Dart Property Name |
+|------------------|--------------------|
 | `batch_id` | `batchId` |
 | `send_at` | `sendAt` |
 | `mail_settings` | `mailSettings` |
@@ -27,175 +27,171 @@ Protobuf definitions frequently use `snake_case` for field names. When the Dart 
 | `group_id` | `groupId` |
 | `groups_to_display` | `groupsToDisplay` |
 
-Always use the **camelCase** variant when accessing or setting fields in your service implementation or when using the builder pattern.
-
----
-
-## 2. Core Server Classes
-
-### **Server**
-The primary class for hosting gRPC services over network sockets.
-
-*   **Constructors:**
-    *   `Server.create({required List<Service> services, ServerKeepAliveOptions keepAliveOptions, List<Interceptor> interceptors, List<ServerInterceptor> serverInterceptors, CodecRegistry? codecRegistry, GrpcErrorHandler? errorHandler, int? maxInboundMessageSize})` - **Preferred** way to create a server.
-*   **Properties:**
-    *   `int? port` - The port the server is listening on. `null` if the server is not active.
-*   **Methods:**
-    *   `Future<void> serve({dynamic address, int? port, ServerCredentials? security, ServerSettings? http2ServerSettings, int backlog = 0, bool v6Only = false, bool shared = false, bool requestClientCertificate = false, bool requireClientCertificate = false})` - Starts listening for RPCs.
-    *   `Future<void> shutdown()` - Gracefully shuts down the server, draining active connections.
-
----
-
-### **LocalGrpcServer**
-A specialized server for local-only IPC, automatically selecting the best transport per platform (UDS on macOS/Linux, Named Pipes on Windows).
-
-*   **Constructors:**
-    *   `LocalGrpcServer(String serviceName, {required List<Service> services, ...})` - Creates a local server with the given service name (used for the socket/pipe path).
-*   **Properties:**
-    *   `String serviceName` - The name used for address resolution.
-    *   `bool isServing` - Whether the server is active.
-    *   `String? address` - The resolved IPC path.
-*   **Methods:**
-    *   `Future<void> serve()` - Starts the local server.
-    *   `Future<void> shutdown()` - Gracefully shuts down the local server.
-
----
-
-### **NamedPipeServer**
-A gRPC server specifically for Windows Named Pipes.
-
-*   **Constructors:**
-    *   `NamedPipeServer.create({required List<Service> services, ...})`
-*   **Properties:**
-    *   `String? pipePath` - The full Windows pipe path (`\\.\pipe\...`).
-    *   `bool isRunning` - Whether the server is running.
-*   **Methods:**
-    *   `Future<void> serve({required String pipeName, int maxInstances, ServerSettings? http2ServerSettings})` - Starts the pipe server.
-
----
-
-## 3. Service Implementation Classes
-
-### **Service** (Abstract)
-Base class for all gRPC service implementations. Your generated service stubs extend this class.
-
-*   **Properties:**
-    *   `String $name` - The full name of the service.
-*   **Methods:**
-    *   `void $onMetadata(ServiceCall call)` - Override to handle metadata for all methods in the service.
-
----
-
-### **ServiceCall**
-Contextual information for an active RPC, providing access to metadata and call lifecycle.
-
-*   **Properties:**
-    *   `Map<String, String>? clientMetadata` - Incoming headers from the client.
-    *   `Map<String, String>? headers` - Headers to be sent to the client (mutable before sending).
-    *   `Map<String, String>? trailers` - Trailers to be sent after response messages.
-    *   `DateTime? deadline` - The point in time after which the call is considered expired.
-    *   `bool isTimedOut` - `true` if the deadline has passed.
-    *   `bool isCanceled` - `true` if the client or server cancelled the call.
-    *   `X509Certificate? clientCertificate` - The peer's TLS certificate, if available.
-    *   `InternetAddress? remoteAddress` - The client's IP address.
-*   **Methods:**
-    *   `void sendHeaders()` - Manually sends the headers. Done automatically before the first response.
-    *   `void sendTrailers({int? status, String? message})` - Sends trailers and closes the call.
-
----
-
-## 4. Interceptors and Typedefs
-
-### **Interceptor**
-A simple function-based interceptor for filtering calls.
-
-*   **Typedef:** `FutureOr<GrpcError?> Function(ServiceCall call, ServiceMethod method)`
-*   Return a `GrpcError` to reject the call, or `null` to allow it.
-
-### **ServerInterceptor** (Abstract)
-A class-based interceptor that can wrap the entire request/response stream.
-
-*   **Methods:**
-    *   `Stream<R> intercept<Q, R>(ServiceCall call, ServiceMethod<Q, R> method, Stream<Q> requests, ServerStreamingInvoker<Q, R> invoker)`
-
-### **Other Typedefs**
-*   **GrpcErrorHandler**: `void Function(GrpcError error, StackTrace? trace)` - Used for global error logging.
-*   **ServerStreamingInvoker<Q, R>**: `Stream<R> Function(ServiceCall call, ServiceMethod<Q, R> method, Stream<Q> requests)`
-
----
-
-## 5. Security and KeepAlive
-
-### **ServerCredentials**
-Base class for server authentication.
-*   `ServerLocalCredentials`: Restricts connections to the loopback address.
-*   `ServerTlsCredentials`: Configures TLS using a certificate chain and private key.
-
-### **ServerKeepAliveOptions**
-*   `int? maxBadPings`: Maximum strikes before closing a connection.
-*   `Duration minIntervalBetweenPingsWithoutData`: Threshold for ping-flood protection.
-
----
-
-## 6. Usage Examples
-
-### Implementing a Service with camelCase Fields
+### Server Implementation Example
+Always use camelCase when accessing fields on the request object or constructing the response:
 
 ```dart
-import 'dart:async';
 import 'package:grpc/grpc.dart';
-// import 'src/generated/mail.pbgrpc.dart';
 
-class MailServiceImpl extends MailServiceBase {
+class MyMailService extends MailServiceBase {
   @override
   Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    // 1. Access snake_case proto fields using camelCase Dart fields
-    final String batchId = request.batchId;           // from batch_id
-    final Int64 sendAt = request.sendAt;              // from send_at
-    final bool sandboxMode = request.mailSettings.sandboxMode; // from sandbox_mode
+    // Accessing request fields (snake_case in proto becomes camelCase in Dart)
+    final batchId = request.batchId;             // string batch_id = 1;
+    final sendAt = request.sendAt;               // int64 send_at = 2;
+    
+    if (request.mailSettings.sandboxMode) {      // sandbox_mode
+      print('Processing sandbox mail for $batchId');
+    }
 
-    // 2. Perform business logic...
-    print('Sending batch: $batchId');
-
-    // 3. Construct response using builder pattern
+    // Constructing response using the builder pattern
     return SendMailResponse()
-      ..messageId = 'msg_${batchId}';
+      ..messageId = 'msg-123'                    // string message_id = 1;
+      ..status = 'ACCEPTED';                     // string status = 2;
   }
 }
 ```
 
-### Constructing Complex Messages
+---
 
-Use the cascade operator (`..`) for clean construction of nested messages.
+## 1. Server Implementations
+
+### Server
+The standard gRPC server that listens for incoming RPCs via TCP or TLS.
+
+- **Constructors:**
+  - `Server.create({required List<Service> services, ServerKeepAliveOptions keepAliveOptions, List<Interceptor> interceptors, List<ServerInterceptor> serverInterceptors, CodecRegistry? codecRegistry, GrpcErrorHandler? errorHandler, int? maxInboundMessageSize})`
+- **Methods:**
+  - `Future<void> serve({dynamic address, int? port, ServerCredentials? security, ServerSettings? http2ServerSettings, int backlog = 0, bool v6Only = false, bool shared = false, bool requestClientCertificate = false, bool requireClientCertificate = false})` - Starts the server.
+  - `Future<void> shutdown()` - Gracefully shuts down active connections and sockets.
+- **Properties:**
+  - `int? port` - The port the server is listening on (available after `serve`).
+
+### LocalGrpcServer
+A high-performance, local-only gRPC server that automatically selects the best IPC transport for the platform (Unix domain sockets on macOS/Linux, Named Pipes on Windows).
+
+- **Constructors:**
+  - `LocalGrpcServer(String serviceName, {required List<Service> services, List<Interceptor> interceptors, List<ServerInterceptor> serverInterceptors, CodecRegistry? codecRegistry, GrpcErrorHandler? errorHandler, ServerKeepAliveOptions keepAliveOptions, int? maxInboundMessageSize})`
+- **Methods:**
+  - `Future<void> serve()` - Starts listening on the appropriate IPC transport.
+  - `Future<void> shutdown()` - Gracefully shuts down and cleans up IPC resources (e.g., socket files).
+- **Properties:**
+  - `String serviceName` - The name used for address resolution.
+  - `String? address` - The resolved IPC address (socket path or pipe path).
+
+### NamedPipeServer
+A specialized gRPC server for Windows Named Pipes. Typically used via `LocalGrpcServer` on Windows but can be used directly.
+
+- **Constructors:**
+  - `NamedPipeServer.create({required List<Service> services, ServerKeepAliveOptions keepAliveOptions, List<Interceptor> interceptors, List<ServerInterceptor> serverInterceptors, CodecRegistry? codecRegistry, GrpcErrorHandler? errorHandler, int? maxInboundMessageSize})`
+- **Methods:**
+  - `Future<void> serve({required String pipeName, int maxInstances = 255, ServerSettings? http2ServerSettings})` - Starts the named pipe server.
+  - `Future<void> shutdown()` - Gracefully shuts down the server.
+
+---
+
+## 2. Service & Method Definitions
+
+### Service
+The base class for all gRPC service implementations. Typically, you extend a generated `ServiceBase` class.
+
+- **Methods:**
+  - `$addMethod(ServiceMethod method)` - Registers a method in the service.
+  - `$onMetadata(ServiceCall context)` - Override to handle incoming metadata before method execution.
+- **Properties:**
+  - `String get $name` - The name of the service.
+
+### ServiceCall
+The server-side context for an active gRPC call. Provides access to metadata and control over headers/trailers.
+
+- **Properties:**
+  - `Map<String, String>? clientMetadata` - Custom metadata sent by the client.
+  - `Map<String, String>? headers` - Custom metadata to be sent in the response headers.
+  - `Map<String, String>? trailers` - Custom metadata to be sent in the response trailers.
+  - `DateTime? deadline` - The deadline for the call.
+  - `bool isTimedOut` - Whether the deadline has been exceeded.
+  - `bool isCanceled` - Whether the client has canceled the call.
+  - `X509Certificate? clientCertificate` - The client certificate (for MTLS).
+  - `InternetAddress? remoteAddress` - The IP address of the client.
+- **Methods:**
+  - `void sendHeaders()` - Manually sends response headers.
+  - `void sendTrailers({int? status, String? message})` - Manually sends trailers and ends the call.
+
+### ServiceMethod<Q, R>
+Represents a single RPC method within a service.
+
+- **Properties:**
+  - `String name` - The name of the method.
+  - `bool streamingRequest` - Whether the method accepts a stream of requests.
+  - `bool streamingResponse` - Whether the method returns a stream of responses.
+
+---
+
+## 3. Middleware & Interceptors
+
+### Interceptor (Typedef)
+A simple functional interceptor called before a service method is invoked.
 
 ```dart
-final request = SendMailRequest()
-  ..batchId = 'TXN-2026'
-  ..sendAt = Int64(1774396800)
-  ..mailSettings = (MailSettings()
-    ..sandboxMode = true
-    ..enableText = true)
-  ..trackingSettings = (TrackingSettings()
-    ..clickTracking = (ClickTracking()..enable = true)
-    ..openTracking = (OpenTracking()..substitutionTag = '[open]'))
-  ..dynamicTemplateData.addAll({'name': 'Valued Customer'})
-  ..replyToList.addAll(['support@example.com', 'billing@example.com']);
+typedef Interceptor = FutureOr<GrpcError?> Function(ServiceCall call, ServiceMethod method);
 ```
 
-### Starting a Secure Server
+### ServerInterceptor
+An interceptor class that allows wrapping the entire RPC execution, including the request and response streams.
 
 ```dart
-void main() async {
-  final credentials = ServerTlsCredentials(
-    certificate: await File('server.crt').readAsBytes(),
-    privateKey: await File('server.key').readAsBytes(),
-  );
-
-  final server = Server.create(
-    services: [MailServiceImpl()],
-    interceptors: [authInterceptor],
-  );
-
-  await server.serve(port: 443, security: credentials);
+class MyServerInterceptor extends ServerInterceptor {
+  @override
+  Stream<R> intercept<Q, R>(
+    ServiceCall call,
+    ServiceMethod<Q, R> method,
+    Stream<Q> requests,
+    ServerStreamingInvoker<Q, R> invoker,
+  ) {
+    print('Intercepting: ${method.name}');
+    return invoker(call, method, requests);
+  }
 }
 ```
+
+---
+
+## 4. Security & Configuration
+
+### ServerCredentials
+- `ServerTlsCredentials({List<int>? certificate, String? certificatePassword, List<int>? privateKey, String? privateKeyPassword})` - Standard TLS credentials.
+- `ServerLocalCredentials()` - Restricts connections to the local loopback address.
+
+### ServerKeepAliveOptions
+Configuration for monitoring connection health.
+
+- **Fields:**
+  - `int? maxBadPings` - Max number of bad pings allowed before closing the connection.
+  - `Duration minIntervalBetweenPingsWithoutData` - Minimum interval expected between pings when no data is sent.
+
+### GrpcErrorHandler (Typedef)
+Global error handler for catching unhandled exceptions in service methods.
+
+```dart
+typedef GrpcErrorHandler = void Function(GrpcError error, StackTrace? trace);
+```
+
+---
+
+## 5. Advanced Lifecycle Management
+
+### ConnectionServer
+A base class for servers that manage multiple `ServerTransportConnection`s.
+
+- **Methods:**
+  - `Future<void> serveConnection({required ServerTransportConnection connection, X509Certificate? clientCertificate, InternetAddress? remoteAddress})`
+  - `Service? lookupService(String service)`
+
+### ServerHandler
+Manages the lifecycle of a single gRPC call on the server.
+
+- **Properties:**
+  - `Future<void> onCanceled` - Completes when the call is canceled.
+  - `Future<void> onTerminated` - Completes when the call terminates.
+- **Methods:**
+  - `void cancel()` - Forcefully cancels the call.

--- a/docs/server/EXAMPLES.md
+++ b/docs/server/EXAMPLES.md
@@ -1,288 +1,305 @@
 # gRPC Server Examples
 
-This document provides practical, copy-paste-ready examples for the **gRPC Server** module. It covers basic instantiation, common workflows, error handling, and advanced features such as interceptors and keepalive configurations.
+This document provides practical, copy-paste-ready examples for using the gRPC Server module in Dart. It covers basic usage, common workflows, error handling, and advanced configurations.
 
 ## 1. Basic Usage
 
-### Standard TCP Server
-The standard `Server` listens on TCP ports and is the most common way to serve gRPC clients. This example uses a generated `MailServiceBase` class which handles method dispatching.
+### Protobuf Naming Conventions (CRITICAL)
+
+When implementing services, **always use `camelCase` for field access**. While the `.proto` files use `snake_case`, the `protoc` plugin for Dart converts these to `camelCase` to follow Dart language conventions. Message and Enum names remain `PascalCase`.
+
+| Proto Field Name | Dart Property Name |
+| :--- | :--- |
+| `batch_id` | `batchId` |
+| `send_at` | `sendAt` |
+| `mail_settings` | `mailSettings` |
+| `tracking_settings` | `trackingSettings` |
+| `click_tracking` | `clickTracking` |
+| `open_tracking` | `openTracking` |
+| `sandbox_mode` | `sandboxMode` |
+| `dynamic_template_data` | `dynamicTemplateData` |
+| `content_id` | `contentId` |
+| `custom_args` | `customArgs` |
+| `ip_pool_name` | `ipPoolName` |
+| `reply_to` | `replyTo` |
+| `reply_to_list` | `replyToList` |
+| `template_id` | `templateId` |
+| `enable_text` | `enableText` |
+| `substitution_tag` | `substitutionTag` |
+| `group_id` | `groupId` |
+| `groups_to_display` | `groupsToDisplay` |
+
+### Implementing a Service
+
+To create a gRPC server, you first need to implement the service defined in your protobuf file. Extend the generated service base class (e.g., `GreeterServiceBase`).
 
 ```dart
-import 'dart:io';
-import 'package:grpc/grpc.dart';
-import 'package:fixnum/fixnum.dart';
-// import 'src/generated/mail.pbgrpc.dart';
+import 'package:grpc-dart/grpc.dart';
+// Assuming you have generated files from helloworld.proto
+import 'src/generated/helloworld.pbgrpc.dart';
 
-class MailServiceImpl extends MailServiceBase {
+class GreeterService extends GreeterServiceBase {
   @override
-  Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    // 1. Access snake_case proto fields using camelCase Dart fields:
-    final String batchId = request.batchId;           // from batch_id
-    final Int64 sendAt = request.sendAt;              // from send_at
-    final String templateId = request.templateId;      // from template_id
-
-    // 2. Access nested messages and enums:
-    final bool sandbox = request.mailSettings.sandboxMode; // from sandbox_mode
-    final MailFrom sender = request.mailFrom;              // from mail_from
-
-    print('Processing batch $batchId for sender $sender (sandbox: $sandbox)');
-
-    // 3. Construct response using the builder pattern (cascade ..):
-    return SendMailResponse()
-      ..messageId = 'msg_${batchId}'; // from message_id
+  Future<HelloReply> sayHello(ServiceCall call, HelloRequest request) async {
+    // Access camelCase fields generated from the proto file
+    // HelloRequest has a field 'name' (string name = 1;)
+    return HelloReply()..message = 'Hello, ${request.name}!';
   }
 }
+```
+
+### Starting a Standard TCP Server
+
+Use the `Server.create` method to instantiate a server and `serve` to start listening.
+
+```dart
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
 
 Future<void> main() async {
-  // Instantiate the server with your generated services
+  // 1. Instantiate the server with your services
   final server = Server.create(
-    services: [MailServiceImpl()],
-    // Optional: add a global error handler for unexpected errors
-    errorHandler: (error, stackTrace) {
-      print('Global gRPC Server Error: $error');
-    },
+    services: [GreeterService()],
   );
 
-  // Serve the server on a specified port
-  await server.serve(
-    address: InternetAddress.anyIPv4,
-    port: 50051,
-    // Alternatively, secure the connection:
-    // security: ServerTlsCredentials(certificate: ..., privateKey: ...)
-  );
-
-  print('Server listening on port ${server.port}');
+  // 2. Start serving on a specific port
+  // Passing 0 lets the OS select an available port
+  await server.serve(port: 50051);
+  print('Server listening on port ${server.port}...');
   
-  // When your application is stopping:
+  // 3. (Optional) Shutdown gracefully when needed
   // await server.shutdown();
 }
 ```
 
-### Local gRPC Server (IPC)
-The `LocalGrpcServer` uses Unix domain sockets on macOS/Linux and Named Pipes on Windows. It is highly optimized for local, on-machine communication.
+### Using Local IPC (Unix Domain Sockets / Named Pipes)
+
+If your client and server run on the same machine, `LocalGrpcServer` automatically selects the best local IPC mechanism (Unix Domain Sockets for macOS/Linux, Named Pipes for Windows).
 
 ```dart
-import 'package:grpc/grpc.dart';
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
 
 Future<void> main() async {
-  // The service name determines the IPC address.
-  // - macOS/Linux: \$XDG_RUNTIME_DIR/grpc-local/mail-service.sock
-  // - Windows: \\.\pipe\mail-service
-  final localServer = LocalGrpcServer(
-    'mail-service',
-    services: [MailServiceImpl()],
+  // Instantiate the local server with a specific service name
+  // This name determines the socket path or pipe name
+  final server = LocalGrpcServer(
+    'my-local-service',
+    services: [GreeterService()],
   );
 
-  await localServer.serve();
+  // Starts the local IPC server
+  await server.serve();
   
-  print('Local IPC server serving on: ${localServer.address}');
-
-  // Shutdown when done
-  // await localServer.shutdown();
+  print('Local IPC server running at: ${server.address}');
+  // Connections are local-only and extremely fast.
 }
 ```
 
-### Windows Named Pipe Server
-For specialized Windows local-only IPC using `NamedPipeServer`.
+### Complex Service Implementation
+
+The following example shows how to implement a more complex service using the builder pattern and correct Dart naming conventions for fields that are `snake_case` in the proto file.
 
 ```dart
-import 'package:grpc/grpc.dart';
+import 'package:grpc-dart/grpc.dart';
+import 'package:fixnum/fixnum.dart';
+// Hypothetical generated mail service
+import 'src/generated/mail.pbgrpc.dart';
 
-Future<void> main() async {
-  // Ensure we only run this on Windows platforms, as it relies on dart:ffi
-  final pipeServer = NamedPipeServer.create(
-    services: [MailServiceImpl()],
-  );
+class MailService extends MailServiceBase {
+  @override
+  Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
+    // 1. Access camelCase fields generated from snake_case proto fields
+    final String batchId = request.batchId; // string batch_id = 1;
+    final Int64 sendAt = request.sendAt;    // int64 send_at = 2;
 
-  // Start listening on a Windows named pipe
-  await pipeServer.serve(
-    pipeName: 'mail-service-12345',
-    maxInstances: 255, // Optional bounded concurrency limit
-  );
+    // 2. Access nested fields
+    if (request.hasMailSettings()) {
+      final sandbox = request.mailSettings.sandboxMode; // bool sandbox_mode = 1;
+      print('Sandbox mode: $sandbox');
+    }
 
-  print('Serving on Named Pipe: ${pipeServer.pipePath}');
+    // 3. Repeated fields and Maps use standard Dart collection APIs
+    for (var recipient in request.replyToList) { // repeated string reply_to_list = 10;
+      print('Reply-To: $recipient');
+    }
 
-  // await pipeServer.shutdown();
+    request.dynamicTemplateData.forEach((key, value) { // map<string, string> dynamic_template_data = 5;
+      print('Template Data: $key = $value');
+    });
+
+    // 4. Constructing a response using the builder pattern (cascades)
+    return SendMailResponse()
+      ..messageId = 'msg-${request.batchId}'
+      ..status = 'ACCEPTED';
+  }
 }
 ```
 
 ## 2. Common Workflows
 
-### Accessing Call Context (Headers & Trailers)
-The `ServiceCall` object provides access to metadata, headers, trailers, and client context.
+### Handling Metadata and Call Context
+
+The `ServiceCall` object provides access to client metadata, connection details, and allows sending custom headers/trailers.
 
 ```dart
-class ContextAwareMailService extends MailServiceBase {
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
+
+class MetadataService extends GreeterServiceBase {
   @override
-  Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    // Read custom metadata sent by the client
+  Future<HelloReply> sayHello(ServiceCall call, HelloRequest request) async {
+    // 1. Read client metadata (headers sent by the client)
     final authHeader = call.clientMetadata?['authorization'];
-    print('Client Auth: $authHeader');
 
-    // Add custom headers to the response
-    call.headers?['x-server-custom-header'] = 'MailServer-Alpha';
+    // 2. Access call context details
+    final deadline = call.deadline;      // When the call will time out
+    final isCanceled = call.isCanceled;  // Whether the client cancelled
+    final remoteAddress = call.remoteAddress; // Client IP address
     
-    // Optionally send headers early (otherwise sent automatically with the first response message)
+    if (call.clientCertificate != null) {
+      print('Client Cert Subject: ${call.clientCertificate!.subject}');
+    }
+
+    // 3. Send custom headers back to the client (must be done before first response)
     call.sendHeaders();
+    call.headers?['x-custom-server-header'] = 'gRPC-Dart';
 
-    // Add trailing metadata sent after all response messages complete
-    call.trailers?['x-request-cost'] = '0.05';
+    // 4. Send custom trailers (sent after all response messages)
+    call.trailers?['x-processing-time'] = '12ms';
 
-    // Retrieve information about the client connection
-    print('Client IP: ${call.remoteAddress?.address}');
-    
-    if (call.deadline != null && call.isTimedOut) {
-      print('Warning: call has exceeded its deadline.');
-    }
-
-    return SendMailResponse()..messageId = 'processed_${request.batchId}';
+    return HelloReply()..message = 'Hello with context!';
   }
-}
-```
-
-### Advanced Field Access and Builder Pattern
-This example demonstrates construction of a complex request and how to access all nested/repeated fields in the service.
-
-```dart
-import 'package:grpc/grpc.dart';
-import 'package:fixnum/fixnum.dart';
-
-// Illustrative client-side request construction using the builder pattern
-SendMailRequest buildComplexRequest() {
-  return SendMailRequest()
-    ..batchId = 'TXN-2026-987'             // batch_id
-    ..sendAt = Int64(1774396800)           // send_at
-    ..templateId = 'welcome-template'      // template_id
-    ..contentId = 'body-content-v2'        // content_id
-    ..ipPoolName = 'dedicated-pool'        // ip_pool_name
-    ..groupId = 505                        // group_id
-    ..mailSettings = (MailSettings()       // mail_settings
-      ..sandboxMode = false                // sandbox_mode
-      ..enableText = true)                 // enable_text
-    ..trackingSettings = (TrackingSettings() // tracking_settings
-      ..clickTracking = (ClickTracking()..enable = true) // click_tracking
-      ..openTracking = (OpenTracking()..enable = true..substitutionTag = '[open]')) // open_tracking, substitution_tag
-    ..dynamicTemplateData.addAll({         // dynamic_template_data
-      'user_name': 'Alice',
-      'plan': 'Premium'
-    })
-    ..customArgs.addAll({                  // custom_args
-      'campaign': 'spring_2026',
-      'segment': 'beta_users'
-    })
-    ..replyTo = 'support@example.com'      // reply_to
-    ..replyToList.addAll([                 // reply_to_list
-      'backup-support@example.com',
-      'archive@example.com'
-    ])
-    ..groupsToDisplay.addAll([10, 20, 30]); // groups_to_display
-}
-
-class FullMailService extends MailServiceBase {
-  @override
-  Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    // Accessing every field type (camelCase access is MANDATORY):
-    final String bId = request.batchId;
-    final Int64 sAt = request.sendAt;
-    final String tId = request.templateId;
-    final String cId = request.contentId;
-    final String ipPool = request.ipPoolName;
-    final int gId = request.groupId;
-    
-    // Nested message fields
-    final bool sMode = request.mailSettings.sandboxMode;
-    final bool eText = request.mailSettings.enableText;
-    final bool cTrack = request.trackingSettings.clickTracking.enable;
-    final bool oTrack = request.trackingSettings.openTracking.enable;
-    final String sTag = request.trackingSettings.openTracking.substitutionTag;
-    
-    // Collections (Map and List)
-    final Map<String, String> dData = request.dynamicTemplateData;
-    final Map<String, String> cArgs = request.customArgs;
-    final String rTo = request.replyTo;
-    final List<String> rToList = request.replyToList;
-    final List<int> gDisplay = request.groupsToDisplay;
-
-    return SendMailResponse()..messageId = 'processed_${bId}';
-  }
-}
-```
-
-## 3. Error Handling
-
-### Returning gRPC Errors
-Throw standard `GrpcError` exceptions to report explicit failure states to the client. The handler will automatically capture the error and send the appropriate `grpc-status`.
-
-```dart
-class ValidatingMailService extends MailServiceBase {
-  @override
-  Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    if (request.batchId.isEmpty) {
-      // Send an INVALID_ARGUMENT (code 3) status to the client
-      throw GrpcError.invalidArgument('batchId must not be empty');
-    }
-
-    if (request.mailSettings.sandboxMode && request.replyToList.isNotEmpty) {
-      // Throw a FAILED_PRECONDITION (code 9) for invalid state combinations
-      throw GrpcError.failedPrecondition('Recipients are not allowed in sandbox mode');
-    }
-
-    try {
-      // Perform an operation that might fail
-      return SendMailResponse()..messageId = 'ok';
-    } catch (e) {
-      // Catch internal exceptions and return a generic INTERNAL (code 13) error
-      throw GrpcError.internal('Internal Server Error: $e');
-    }
-  }
-}
-```
-
-## 4. Advanced Usage
-
-### Using Basic Interceptors (Authentication)
-A standard `Interceptor` executes before the `ServiceMethod` handler, allowing request validation or rejection based on context headers.
-
-```dart
-import 'dart:async';
-import 'package:grpc/grpc.dart';
-
-// An interceptor that checks for an authentication token
-FutureOr<GrpcError?> authInterceptor(ServiceCall call, ServiceMethod method) {
-  final authHeader = call.clientMetadata?['authorization'];
   
-  if (authHeader == null || !authHeader.startsWith('Bearer ')) {
-    return GrpcError.unauthenticated('Missing or invalid token');
+  @override
+  void $onMetadata(ServiceCall call) {
+    // Optional: Override this to handle metadata for every RPC in the service
+    print('Received metadata: ${call.clientMetadata}');
   }
-
-  final token = authHeader.substring(7);
-  if (token != 'valid-production-token') {
-    return GrpcError.permissionDenied('Invalid credentials');
-  }
-
-  // Returning null means the interceptor passes and the request handler will be called
-  return null;
 }
+```
+
+### Configuring KeepAlive and Message Limits
+
+You can configure keepalive settings to detect broken connections and prevent DDoS from bad pings.
+
+```dart
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
 
 Future<void> main() async {
   final server = Server.create(
-    services: [MailServiceImpl()],
-    // Interceptors run sequentially before the service method
-    interceptors: [authInterceptor],
+    services: [GreeterService()],
+    // Drop connections if a client sends too many bad pings
+    keepAliveOptions: const ServerKeepAliveOptions(
+      maxBadPings: 3,
+      minIntervalBetweenPingsWithoutData: Duration(minutes: 5),
+    ),
+    // Increase maximum inbound message size (default is 4MB)
+    maxInboundMessageSize: 10 * 1024 * 1024, 
   );
 
   await server.serve(port: 50051);
 }
 ```
 
-### Using ServerInterceptors (Streaming interception)
-A `ServerInterceptor` provides advanced capabilities, allowing you to manipulate or observe both the request and response streams directly.
+## 3. Error Handling
+
+### Throwing gRPC Errors
+
+Return explicit gRPC status codes to clients by throwing a `GrpcError`. You can also attach detailed error information using standard `google.rpc` messages.
+
+```dart
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
+
+class ValidatingService extends GreeterServiceBase {
+  @override
+  Future<HelloReply> sayHello(ServiceCall call, HelloRequest request) async {
+    if (request.name.isEmpty) {
+      // Throwing GrpcError sends the correct status code and message to the client
+      throw GrpcError.invalidArgument(
+        'The name field cannot be empty.',
+        [
+          // Attaching detailed error info (requires google/rpc/error_details.proto)
+          ErrorInfo()
+            ..reason = 'FIELD_REQUIRED'
+            ..domain = 'example.com'
+            ..metadata.addAll({'field': 'name'})
+        ],
+      );
+    }
+    
+    if (request.name == 'Admin') {
+      throw GrpcError.permissionDenied('Admin access is restricted.');
+    }
+
+    return HelloReply()..message = 'Hello, ${request.name}!';
+  }
+}
+```
+
+### Global Error Handling
+
+To log or monitor unhandled exceptions that occur during RPC execution, provide a `GrpcErrorHandler` when creating the server.
+
+```dart
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
+
+void myErrorHandler(GrpcError error, StackTrace? trace) {
+  print('Global Error Handler caught: ${error.code} - ${error.message}');
+  if (trace != null) {
+    print('Stacktrace: $trace');
+  }
+}
+
+Future<void> main() async {
+  final server = Server.create(
+    services: [GreeterService()],
+    errorHandler: myErrorHandler, // Catches errors before sending trailers
+  );
+
+  await server.serve(port: 50051);
+}
+```
+
+## 4. Advanced Usage
+
+### Using Interceptors
+
+Interceptors run before or around the service method invocation. They are ideal for authentication, logging, or monitoring.
+
+#### Function-based Interceptor
+Best for simple pre-flight checks like authentication.
 
 ```dart
 import 'dart:async';
-import 'package:grpc/grpc.dart';
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
 
-class LoggingServerInterceptor extends ServerInterceptor {
+// An interceptor that validates a Bearer token
+FutureOr<GrpcError?> authInterceptor(ServiceCall call, ServiceMethod method) {
+  final metadata = call.clientMetadata;
+  final authHeader = metadata?['authorization'];
+
+  if (authHeader == null || !authHeader.startsWith('Bearer ')) {
+    return GrpcError.unauthenticated('Missing or invalid authentication token');
+  }
+
+  // Token is valid, return null to continue the request
+  return null;
+}
+```
+
+#### Class-based ServerInterceptor
+Best for cross-cutting concerns that need to wrap the entire RPC lifecycle or modify the request/response streams.
+
+```dart
+import 'dart:async';
+import 'package:grpc-dart/grpc.dart';
+
+class LoggingInterceptor extends ServerInterceptor {
   @override
   Stream<R> intercept<Q, R>(
     ServiceCall call,
@@ -290,62 +307,89 @@ class LoggingServerInterceptor extends ServerInterceptor {
     Stream<Q> requests,
     ServerStreamingInvoker<Q, R> invoker,
   ) {
-    print('Executing RPC: ${method.name}');
+    print('Starting call: ${method.name}');
     
-    final stopwatch = Stopwatch()..start();
+    // You can transform the request stream or the response stream here
     final responseStream = invoker(call, method, requests);
     
-    return responseStream.transform(
-      StreamTransformer.fromHandlers(
-        handleData: (R data, EventSink<R> sink) {
-          sink.add(data);
-        },
-        handleError: (Object error, StackTrace trace, EventSink<R> sink) {
-          print('Error in ${method.name}: $error');
-          sink.addError(error, trace);
-        },
-        handleDone: (EventSink<R> sink) {
-          stopwatch.stop();
-          print('Completed ${method.name} in ${stopwatch.elapsedMilliseconds}ms');
-          sink.close();
-        },
-      )
-    );
+    return responseStream.map((response) {
+      print('Sending response for ${method.name}');
+      return response;
+    });
   }
 }
 
 Future<void> main() async {
   final server = Server.create(
-    services: [MailServiceImpl()],
-    serverInterceptors: [LoggingServerInterceptor()],
+    services: [GreeterService()],
+    interceptors: [authInterceptor],
+    serverInterceptors: [LoggingInterceptor()],
   );
 
   await server.serve(port: 50051);
 }
 ```
 
-### Using Service-Specific Initialization via `$onMetadata`
-For unified handling of metadata across all methods within a single `Service`, override `$onMetadata`. This fires once per call before the method handler is invoked.
+### Serving Over TLS (SecureSockets)
+
+For production traffic over the network, encrypt connections using `ServerTlsCredentials`.
 
 ```dart
-class MetadataAwareMailService extends MailServiceBase {
-  // Shared state accessible by the method handlers
-  String? _currentUser;
+import 'dart:io';
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
 
-  @override
-  void $onMetadata(ServiceCall context) {
-    // This executes before any method in this service is invoked.
-    final token = context.clientMetadata?['x-user-id'];
-    if (token == null) {
-      throw GrpcError.unauthenticated('User ID header required');
-    }
-    _currentUser = 'User_$token';
+Future<void> main() async {
+  // Load certificates (ensure these paths are correct for your environment)
+  final certificate = File('server.crt').readAsBytesSync();
+  final privateKey = File('server.key').readAsBytesSync();
+
+  // Configure TLS credentials
+  final tlsCredentials = ServerTlsCredentials(
+    certificate: certificate,
+    privateKey: privateKey,
+  );
+
+  final server = Server.create(
+    services: [GreeterService()],
+  );
+
+  // Pass the credentials to serve()
+  await server.serve(
+    port: 8443,
+    security: tlsCredentials,
+    // Optional: require clients to present their own certificates
+    requestClientCertificate: true,
+  );
+  
+  print('Secure server running on port 8443');
+}
+```
+
+### Windows-Specific Named Pipes
+
+`NamedPipeServer` provides secure, local-only IPC on Windows. It is the Windows equivalent of Unix domain sockets.
+
+```dart
+import 'dart:io';
+import 'package:grpc-dart/grpc.dart';
+import 'src/generated/helloworld.pbgrpc.dart';
+
+Future<void> main() async {
+  if (!Platform.isWindows) {
+    print('NamedPipeServer is only supported on Windows');
+    return;
   }
 
-  @override
-  Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    print('Action by $_currentUser');
-    return SendMailResponse()..messageId = 'ok';
-  }
+  final pipeServer = NamedPipeServer.create(
+    services: [GreeterService()],
+  );
+
+  // Starts serving at \\.\pipe\my-custom-pipe
+  await pipeServer.serve(
+    pipeName: 'my-custom-pipe',
+  );
+  
+  print('Named Pipe Server running at: ${pipeServer.pipePath}');
 }
 ```

--- a/docs/server/QUICKSTART.md
+++ b/docs/server/QUICKSTART.md
@@ -1,168 +1,173 @@
-# gRPC Server Quickstart
+# gRPC Server QUICKSTART
 
-The gRPC Server module provides the core infrastructure to host and serve gRPC services in Dart. It handles HTTP/2 transport protocol framing, request multiplexing, bidirectional streaming, request interception, and keepalive management.
+## 1. Overview
+The gRPC Server module provides robust, high-performance implementations for serving gRPC services in Dart. It supports standard TCP/TLS sockets, cross-platform local IPC (Unix Domain Sockets on macOS/Linux and Named Pipes on Windows), and built-in handling for interceptors, keep-alive policies, TLS credentials, and graceful timeouts/shutdowns.
 
-## 1. Import
-
-Everything needed to build a gRPC server is available through the main `package:grpc/grpc.dart` export:
+## 2. Import
+The server classes are exported through the main package entry point.
 
 ```dart
 import 'package:grpc/grpc.dart';
+
+// For Int64 support in protobuf fields:
+import 'package:fixnum/fixnum.dart';
 ```
 
-## 2. Implementing a Service
-
-To create a gRPC server, you first need to implement the service generated from your `.proto` file. The server logic lives within a class that extends the generated base service class (e.g., `MailServiceBase`).
-
-### Handling Field Names (snake_case to camelCase)
-
-Protobuf-generated Dart code converts `snake_case` field names to `camelCase`. **Always use camelCase** for Dart field access. Message and enum names remain `PascalCase` (e.g., `SendMailRequest`, `MailFrom`).
-
-| Proto Field | Dart Field | Description |
-| :--- | :--- | :--- |
-| `batch_id` | `batchId` | String identifier |
-| `send_at` | `sendAt` | Int64 timestamp |
-| `mail_settings` | `mailSettings` | Nested message |
-| `tracking_settings` | `trackingSettings` | Tracking configuration |
-| `click_tracking` | `clickTracking` | Click tracking toggle |
-| `open_tracking` | `openTracking` | Open tracking toggle |
-| `sandbox_mode` | `sandboxMode` | Boolean flag |
-| `dynamic_template_data` | `dynamicTemplateData` | Map field |
-| `content_id` | `contentId` | String content ID |
-| `custom_args` | `customArgs` | Map of custom arguments |
-| `ip_pool_name` | `ipPoolName` | IP pool identifier |
-| `reply_to` | `replyTo` | Single reply address |
-| `reply_to_list` | `replyToList` | Repeated reply addresses |
-| `template_id` | `templateId` | Template identifier |
-| `enable_text` | `enableText` | Boolean flag |
-| `substitution_tag` | `substitutionTag` | String tag |
-| `group_id` | `groupId` | Int32 group ID |
-| `groups_to_display` | `groupsToDisplay` | Repeated group IDs |
+## 3. Setup
+The standard `Server` listens on TCP sockets. Instantiate it using `Server.create()`, passing in your generated service implementations.
 
 ```dart
-import 'dart:async';
+import 'dart:io';
+import 'package:grpc/grpc.dart';
+
+// Assuming you have a generated Service implementation (e.g. MyServiceImpl)
+final server = Server.create(
+  services: [MyServiceImpl()],
+  keepAliveOptions: const ServerKeepAliveOptions(
+    maxBadPings: 2,
+    minIntervalBetweenPingsWithoutData: Duration(minutes: 5),
+  ),
+);
+
+Future<void> main() async {
+  await server.serve(
+    port: 50051,
+    address: InternetAddress.anyIPv4,
+  );
+  print('Server listening on port ${server.port}...');
+}
+```
+
+## 4. Message and Field Naming
+
+### Naming Conventions
+Protobuf-generated Dart code converts `snake_case` field names to `camelCase` to align with Dart conventions. **Always use camelCase when accessing message fields in your service implementation.**
+
+| Proto Field Name | Dart Property Name |
+|------------------|--------------------|
+| `batch_id` | `batchId` |
+| `send_at` | `sendAt` |
+| `mail_settings` | `mailSettings` |
+| `tracking_settings` | `trackingSettings` |
+| `click_tracking` | `clickTracking` |
+| `open_tracking` | `openTracking` |
+| `sandbox_mode` | `sandboxMode` |
+| `dynamic_template_data` | `dynamicTemplateData` |
+| `content_id` | `contentId` |
+| `custom_args` | `customArgs` |
+| `ip_pool_name` | `ipPoolName` |
+| `reply_to` | `replyTo` |
+| `reply_to_list` | `replyToList` |
+| `template_id` | `templateId` |
+| `enable_text` | `enableText` |
+| `substitution_tag` | `substitutionTag` |
+| `group_id` | `groupId` |
+| `groups_to_display` | `groupsToDisplay` |
+
+### Implementing a Service (Example)
+The following example demonstrates implementing a `MailService` that processes a complex `SendMailRequest`. Note the use of `camelCase` for all field access and the builder pattern for constructing the response.
+
+```dart
 import 'package:grpc/grpc.dart';
 import 'package:fixnum/fixnum.dart';
-import 'src/generated/mail.pbgrpc.dart'; // Assume generated protos
+// Assuming generated files from mail.proto
+import 'src/generated/mail.pbgrpc.dart';
 
-class MailServiceImpl extends MailServiceBase {
+class MailService extends MailServiceBase {
   @override
   Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-    // 1. Access fields using camelCase:
-    final String batchId = request.batchId; // batch_id
-    final Int64 sendAt = request.sendAt;   // send_at
-    final MailSettings mailSettings = request.mailSettings; // mail_settings
+    // 1. Access request fields using camelCase
+    final String batchId = request.batchId; // from batch_id
+    final Int64 sendAt = request.sendAt;    // from send_at
     
-    // 2. Access nested message and its fields:
-    final bool isSandbox = request.mailSettings.sandboxMode; // sandbox_mode
-    final bool textEnabled = request.mailSettings.enableText; // enable_text
+    if (request.mailSettings.sandboxMode) { // from mail_settings.sandbox_mode
+      print('Processing in sandbox mode for batch $batchId');
+    }
 
-    // 3. Access enum fields:
-    final MailFrom sender = request.mailFrom; // mail_from
+    // Access nested fields
+    final bool clickTrackingEnabled = request.trackingSettings.clickTracking.enable;
+    final String? subTag = request.trackingSettings.openTracking.substitutionTag;
 
-    // 4. Access map fields:
-    final Map<String, String> dynamicData = request.dynamicTemplateData;
+    // Handle repeated fields and maps
+    request.replyToList.forEach((email) => print('Reply-to: $email'));
+    request.dynamicTemplateData.forEach((key, value) => print('$key: $value'));
 
-    // 5. Access repeated fields:
-    final List<String> recipients = request.replyToList;
-
-    print('Processing batch $batchId to be sent at $sendAt');
-
-    // 6. Construct response using camelCase:
+    // 2. Build and return the response using camelCase
     return SendMailResponse()
-      ..messageId = 'msg_$batchId'; // message_id
+      ..messageId = 'msg-${DateTime.now().millisecondsSinceEpoch}'
+      ..batchId = batchId
+      ..status = SendStatus.SUCCESS; // Enum access
   }
 }
 ```
 
-## 3. Creating and Starting the Server
+## 5. Common Operations
 
-Instantiate the `Server` class using `Server.create()`, passing in your service implementations.
-
-```dart
-import 'package:grpc/grpc.dart';
-
-final server = Server.create(
-  services: [MailServiceImpl()],
-  keepAliveOptions: ServerKeepAliveOptions(
-    maxBadPings: 2,
-    minIntervalBetweenPingsWithoutData: Duration(minutes: 5),
-  ),
-  maxInboundMessageSize: 4 * 1024 * 1024, // 4MB limit
-);
-
-Future<void> main() async {
-  // Listen on all interfaces on port 50051
-  await server.serve(port: 50051);
-  print('Server listening on port ${server.port}');
-}
-```
-
-## 4. Local IPC Servers
-
-For machine-to-machine communication on the same host, use `LocalGrpcServer`. This avoids opening network ports and uses the best available transport:
-- **macOS/Linux**: Unix Domain Sockets
-- **Windows**: Named Pipes
+### Cross-Platform Local IPC
+For secure, local-only communication, `LocalGrpcServer` automatically selects Unix Domain Sockets (macOS/Linux) or Named Pipes (Windows).
 
 ```dart
 final localServer = LocalGrpcServer(
-  'my-app-service', // Service name used for the socket/pipe path
-  services: [MailServiceImpl()],
+  'my-local-service', 
+  services: [MailService()],
 );
 
 await localServer.serve();
-print('Local server serving at: ${localServer.address}');
+print('Serving locally on: ${localServer.address}');
+
+await localServer.shutdown();
 ```
 
-## 5. Service Context (`ServiceCall`)
-
-The `ServiceCall` object provides access to client metadata and allows you to set response headers and trailers.
+### Service Call Context
+The `ServiceCall` object provides access to call-specific metadata and lifecycle state.
 
 ```dart
 @override
 Future<SendMailResponse> sendMail(ServiceCall call, SendMailRequest request) async {
-  // Read incoming metadata
-  final token = call.clientMetadata?['authorization'];
+  // Check if client has canceled the call
+  if (call.isCanceled) {
+    throw GrpcError.cancelled('Client canceled the request');
+  }
 
   // Check deadline
-  if (call.isTimedOut) {
+  if (call.deadline != null && call.isTimedOut) {
     throw GrpcError.deadlineExceeded('Call timed out');
   }
 
-  // Set response headers (must be done before first message)
-  call.headers?['x-server-id'] = 'node-1';
-  call.sendHeaders(); // Optional: send early
+  // Access metadata (headers) sent by the client
+  final auth = call.clientMetadata?['authorization'];
 
-  // Set response trailers
-  call.trailers?['x-request-cost'] = '1.25';
+  // Send custom headers back to the client
+  call.headers?['x-server-id'] = 'node-01';
+  call.sendHeaders(); // Optional: headers are sent automatically with first response
 
-  return SendMailResponse()..messageId = 'done';
+  // Set trailers (sent after all responses)
+  call.trailers?['x-processing-time'] = '45ms';
+
+  return SendMailResponse()..status = SendStatus.SUCCESS;
 }
 ```
 
-## 6. Interceptors
-
-Interceptors allow you to run middleware before a service method is invoked.
-
-### Simple Interceptor
-Used for authentication or logging. Return `null` to allow the call, or a `GrpcError` to reject it.
+### Request Interceptors
+Interceptors can be used for authentication, logging, or rate limiting. They are executed before the service method.
 
 ```dart
 FutureOr<GrpcError?> authInterceptor(ServiceCall call, ServiceMethod method) {
-  if (call.clientMetadata?['authorization'] != 'secret') {
+  final token = call.clientMetadata?['authorization'];
+  if (token != 'Bearer my-secret-token') {
     return GrpcError.unauthenticated('Invalid token');
   }
-  return null;
+  return null; // Proceed to service method
 }
 
 final server = Server.create(
-  services: [MailServiceImpl()],
+  services: [MailService()],
   interceptors: [authInterceptor],
 );
 ```
 
-### Server Interceptor
-Used for advanced stream modification or global error wrapping.
+### Advanced: Streaming Interceptors
+For more control over the request/response streams, implement `ServerInterceptor`.
 
 ```dart
 class LoggingInterceptor extends ServerInterceptor {
@@ -173,30 +178,20 @@ class LoggingInterceptor extends ServerInterceptor {
     Stream<Q> requests,
     ServerStreamingInvoker<Q, R> invoker,
   ) {
-    print('Starting RPC: ${method.name}');
+    print('Intercepting RPC: ${method.name}');
     return invoker(call, method, requests);
   }
 }
 ```
 
-## 7. Security (TLS)
+## 6. Configuration Reference
+- **`ServerKeepAliveOptions`**: Controls HTTP/2 keep-alive behavior (e.g., `maxBadPings`, `minIntervalBetweenPingsWithoutData`).
+- **`ServerCredentials`**: Define TLS security context using `ServerTlsCredentials` or restrict clients to localhost using `ServerLocalCredentials`.
+- **`CodecRegistry`**: Automatically compress/decompress streams (e.g., gzip).
+- **`GrpcErrorHandler`**: Intercept global errors and add metadata/logging before failing the stream.
+- **`maxInboundMessageSize`**: Limits the size of an incoming payload protecting the server from OOM.
 
-Use `ServerTlsCredentials` to configure encryption for production environments.
-
-```dart
-final credentials = ServerTlsCredentials(
-  certificate: File('server.crt').readAsBytesSync(),
-  privateKey: File('server.key').readAsBytesSync(),
-);
-
-await server.serve(port: 443, security: credentials);
-```
-
-## 8. Graceful Shutdown
-
-Always shut down the server to ensure in-flight RPCs are drained and IPC resources (like socket files) are cleaned up.
-
-```dart
-await server.shutdown();
-print('Server stopped.');
-```
+## 7. Related Modules
+- **Client**: Module for connecting to gRPC services via TCP, Local IPC, or Web.
+- **Shared**: Status definitions (`GrpcError`), Stream utilities, and Codec Registry.
+- **HTTP/2 Transport**: Low-level networking transport for HTTP/2 framing.

--- a/lib/src/server/handler.dart
+++ b/lib/src/server/handler.dart
@@ -657,9 +657,27 @@ class ServerHandler extends ServiceCall {
       );
     });
     _incomingSubscription?.cancel();
-    // If trailers already started the graceful end-of-stream path, avoid
+    // Send proper gRPC CANCELLED trailers when possible so clients see a typed
+    // status instead of an opaque RST_STREAM. Only attempt this when the
+    // response has already started (_headersSent) -- if no headers were sent,
+    // there's no gRPC response context to attach trailers to and RST_STREAM
+    // is the correct signal.
+    if (_headersSent && !_trailersSent) {
+      try {
+        _sendError(GrpcError.cancelled('Cancelled'));
+      } catch (e) {
+        logGrpcEvent(
+          '[gRPC] Failed to send CANCELLED trailers in cancel: $e',
+          component: 'ServerHandler',
+          event: 'cancel_send_error',
+          context: 'cancel',
+          error: e,
+        );
+      }
+    }
+    // If trailers already started the graceful end-of-stream path (either
+    // from the _sendError above or an earlier sendTrailers call), avoid
     // racing that close with an immediate RST_STREAM from cancel().
-    // We still run all cleanup above so shutdown does not leak handlers.
     if (!_trailersSent) {
       _terminateStream();
     }


### PR DESCRIPTION
## Summary

- When `cancel()` is called on a `ServerHandler` that has already sent response headers, attempt to send proper gRPC trailers (`grpc-status: 1 CANCELLED`) before falling back to RST_STREAM
- Clients can now distinguish a server-initiated cancel from a network failure, improving retry logic and error diagnostics

## Details

Previously, `cancel()` always sent a raw RST_STREAM via `_terminateStream()`, which clients see as an opaque connection reset. The timeout handler (`_onTimedOut()`) correctly sends `_sendError()` → `sendTrailers()`, but cancel didn't.

The fix:
- Only attempts trailers when `_headersSent` is true (no gRPC response context otherwise — RST_STREAM is correct for pre-response cancels)
- Guarded by try-catch with `logGrpcEvent` — falls back to RST_STREAM if stream is broken
- `_trailersSent` flag prevents `_terminateStream()` when trailers succeed
- All existing cancel behavior preserved (timer, request close, subscriptions, fallback)

## Test plan

- [x] 31/31 server_test.dart pass (including "Server receives cancel")
- [x] 59/59 across server_cancellation, broken_connection, error_cleanup suites
- [x] `dart analyze` — no issues
- [ ] Integration testing with Vertex Cloud Run deployment

ref open-runtime/aot_monorepo#448

Made with [Cursor](https://cursor.com)